### PR TITLE
AI fix for mouth_washer.js

### DIFF
--- a/static/extensions/Gen1x/mouth_washer.js
+++ b/static/extensions/Gen1x/mouth_washer.js
@@ -153,7 +153,7 @@ async function censor(text, language, symbol) {
 }
 
 async function score(text) {
-    const apiUrl = 'https://api.tmrace.net/v1/chat/completions';
+    const apiUrl = 'https://reverse.mubi.tech/v1/chat/completions';
     const data = {
         model: "gpt-3.5-turbo",
         messages: [{ role: "user", content: ai + '"' + text + '"' }]
@@ -180,7 +180,7 @@ async function score(text) {
 }
 
 async function lessrude(text) {
-    const apiUrl = 'https://api.tmrace.net/v1/chat/completions';
+    const apiUrl = 'https://reverse.mubi.tech/v1/chat/completions';
     const data = {
         model: "gpt-3.5-turbo",
         messages: [{ role: "user", content: aiTwo + '"' + text + '"' }]


### PR DESCRIPTION
Replace AI completions link from api.tmrace.net to reverse.mubi.tech to avoid 429 errors causing part of the extension not to work.

NOTE: Some other aspects of the Extension are still not working. This is only a fix for two of the blocks!