### PR TITLE
add OOP to More Types extension

### DIFF
--- a/src/lib/Documentation/More-Types.md
+++ b/src/lib/Documentation/More-Types.md
@@ -189,9 +189,14 @@ Like functions, methods can execute code and return a value.
 
 ### Construct
 ```Scratch
-Construct an instance of [Insert Class Here]
+Construct an instance of [Insert Class Here]::#B300FF
 ```
 This block creates an instance of the class, and executes the class on the instance.
+### instanceof
+```Scratch
+is [Insert Anything Here] an instance of [Put in a class, or use the menu]::#B300FF boolean
+```
+It checks if something is an instance of a class.
 ## How to read the console
 
 The console is incredibly complex, but this section will teach you how to read the console.

--- a/src/lib/Documentation/More-Types.md
+++ b/src/lib/Documentation/More-Types.md
@@ -79,7 +79,7 @@ For maps, key can be anything; key can even be the map itself.
 
 ### add to end
 ```scratch
-add [foo] to the end of [Insert Array / Set Here]
+add [foo] to the end of [Insert Array / Set Here]::#B300FF
 ```
 Sets are really just a list of unique values, and arrays are really just a list.
 This block adds a new value and puts it at the end.
@@ -112,6 +112,7 @@ for key [my variable v] value [my variable v] in [Insert Object / Array / Map / 
 It loops through the object / array / set / map. The variable after "key" is the variable which is set to the key. The variable after "value" is the variable which is set to the value.
 For sets, key and value are the same.
 
+There is also a variation of this block which uses the variables from the PenguinMod Temporary Variables extension.
 ### create a symbol and nothing
 ```scratch
 create a symbol::#B300FF reporter
@@ -139,6 +140,58 @@ The first block allows you to execute the function, as the sprite it was created
 
 The seconds block does what the first block does, but it is an input, and it gets you the value that the function returned.
 
+### Classes
+
+```scratch
+anonymous class {
+
+}::#B300FF cap
+
+anonymous class extends [Put in a class, or use the menu] {
+
+}::#B300FF
+```
+
+Classes are similar to functions, as they can execute code, but are slightly different.
+
+Classes are basically blueprints for new objects, that can "extend" each other and be "constructed"
+
+Extending another class is basically taking a blueprint, and modifying it. When a class extends another class, it will have access to a "super" call, which is basically calling the class that it extends before the actual class contents.
+
+However, in More Types, you have no choice but to let the super call run.
+
+The code inside your class can use a "this" block which will be discussed later.
+
+### This
+
+```scratch
+this::#B300FF reporter
+```
+This block allows you to access the object being constructed inside classes, and allow you to access the receiver of the method (discussed later) inside a method.
+
+### Methods
+
+```scratch
+append method [Insert Function Here] with name [foo] to class or object [Insert Object / Array / Set / Map / Class Here]::#B300FF
+
+call method with name [foo] on [Insert Object / Array / Set / Map Here]::#B300FF
+
+call method with name [foo] on [Insert Object / Array / Set / Map Here] and get return value::#B300FF reporter
+```
+
+Methods are functions that are executed with a receiver (the object the method was added to), where the receiver can be access via the "this" block.
+
+When you append a method to an object, it creates an invisible property that can be called.
+
+When you append a method to a class, it will create an invisible property on all current and future instances of the class (and classes that extend that class) that can be called.
+
+Like functions, methods can execute code and return a value.
+
+### Construct
+```Scratch
+Construct an instance of [Insert Class Here]
+```
+This block creates an instance of the class, and executes the class on the instance.
 ## How to read the console
 
 The console is incredibly complex, but this section will teach you how to read the console.

--- a/src/lib/Documentation/More-Types.md
+++ b/src/lib/Documentation/More-Types.md
@@ -188,12 +188,12 @@ When you append a method to a class, it will create an invisible property on all
 Like functions, methods can execute code and return a value.
 
 ### Construct
-```Scratch
+```scratch
 Construct an instance of [Insert Class Here]::#B300FF
 ```
 This block creates an instance of the class, and executes the class on the instance.
 ### instanceof
-```Scratch
+```scratch
 is [Insert Anything Here] an instance of [Put in a class, or use the menu]::#B300FF boolean
 ```
 It checks if something is an instance of a class.

--- a/src/lib/Documentation/More-Types.md
+++ b/src/lib/Documentation/More-Types.md
@@ -1,9 +1,11 @@
 # More Types
-More Types introduces 7 new types to PenguinMod: Object, Array, Set, Map, Symbol, Nothing, and Function. 
+More Types introduces 8 new types to PenguinMod: Object, Array, Set, Map, Symbol, Nothing, Function, and Class. 
 
 These types can be used to do all sorts of things.
 
 All of the new types, except for Nothing, are passed by reference, meaning that each new instance you create is different from every other instance.
+
+More Types also introduces OOP (Object Oriented Programming) to PenguinMod.
 
 NOTE: The square inputs cannot be displayed here, and we have turned them into circular inputs.
 ## Blocks
@@ -14,6 +16,8 @@ Here are the blocks are their usage:
 print [Hello, World!] to console::#B300FF
 ```
 This block outputs a value into the JavaScript console. You can open the console by pressing Ctrl + Shift + I (but don't type anything in if you don't know what you're doing).
+
+More on this block later.
 
 ### set variable to
 ```scratch
@@ -134,3 +138,41 @@ call function [Insert Function Here] and get return value::#B300FF reporter
 The first block allows you to execute the function, as the sprite it was created in, but ignores whatever value the function returned.
 
 The seconds block does what the first block does, but it is an input, and it gets you the value that the function returned.
+
+## How to read the console
+
+The console is incredibly complex, but this section will teach you how to read the console.
+
+The first thing you need to do is find a textbox that says "Filter", and in this textbox you want to type in "MORE TYPES LOG:" without the quotations.
+
+You should see all of the outputs now.
+
+### Reading objects
+
+This section is for when you encounter the following items:
+
+\> PlainObject (Objects)
+
+\> Array (Arrays)
+
+\> Set (Sets)
+
+\> Map (Maps)
+
+\> MORETYPESCLASS (Instances of More Types classes)
+
+For PlainObject, Array, Set, Map, and MORETYPESCLASS, you need to press the arrow, and there should be a piece of text called __values, open the arrow for that, and you should see the raw object.
+
+The raw object is either an object ({...}), an array (\[...\] or Array(n)), a map (Map(n) {... => ...}), or a set (Set(n) {...}}).
+
+For objects, the thingy before the colon (:) is the key, and the thingy after the colon (:) is the value.
+
+For arrays, you need to expand the array, and you should see n: value, where n is the key (starts from 0) and value is the value.
+
+For maps, you need to expand the map, and expand \[\[Entries]], and only look at the items after the colon (:), you should see key => value.
+
+For sets, you need to expand the set, and expand \[\[Entires]], and only look at the items after the colon (:), those items are the values of inside the set.
+
+### Other Items
+
+You can ignore all of the other things that More Types outputs, as they do not provide much information.

--- a/static/extensions/VeryGoodScratcher42/More-Types.js
+++ b/static/extensions/VeryGoodScratcher42/More-Types.js
@@ -1113,7 +1113,7 @@
             kind: "input",
             stack: generator.descendSubstack(block, "SUBSTACK")
           }),
-          anonymousClassExtends: (generator, block) => (console.log(block), {
+          anonymousClassExtends: (generator, block) => ({
             kind: "input",
             stack: generator.descendSubstack(block, "SUBSTACK"),
             "extends": generator.descendInputOfBlock(block, "CLASS")
@@ -1145,9 +1145,9 @@
         js: {
           log: (node, compiler, imports) => {
             let x = compiler.descendInput(node.contents)
-            compiler.source += `console.log(${x.asUnknown()});\n`
-            console.log(x)
-            console.log(compiler)
+            compiler.source += `console.log("MORE TYPES LOG: " ,${x.asUnknown()});\n`
+            //console.log(x)
+            //console.log(compiler)
           },
           newObject: (node, compiler, imports) => {
             let object;
@@ -1397,7 +1397,7 @@
 		blockInfo.tooltip ? res.json.tooltip = blockInfo.tooltip : 0;
 		// Add argument tooltips.
 		/*const args0 = res.json.args0;
-		console.log(args0)
+		//console.log(args0)
 		
 		for (const input in (args0 || {})) {
 		  for (const argument in (blockInfo.arguments || {})) {
@@ -1406,7 +1406,7 @@
 		    }
 		  }
 		}
-		console.log(res.json)*/ // remove all this dev stuff, and argument tooltips prob not needed.
+		//console.log(res.json)*/ // remove all this dev stuff, and argument tooltips prob not needed.
 		return res;
 	}
 	

--- a/static/extensions/VeryGoodScratcher42/More-Types.js
+++ b/static/extensions/VeryGoodScratcher42/More-Types.js
@@ -949,6 +949,23 @@
               }
             }
           },
+          {
+            opcode: "instanceof",
+            func: "noComp",
+            blockType: Scratch.BlockType.BOOLEAN,
+            text: "is [OBJECT] an instance of [CLASS]",
+            arguments: {
+              OBJECT: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "Insert Anything Here"
+              },
+              CLASS: {
+                type: Scratch.ArgumentType.STRING,
+                menu: "defaultClasses",
+                defaultValue: "Put in a class, or use the menu."
+              }
+            }
+          },
           this.makeLabel("Temporary Variables Support"),
           {
             opcode: "iterateObjectTempVars",
@@ -1140,6 +1157,11 @@
           construct: (generator, block) => (generator.script.yields = true, {
             kind: "input",
             "class": generator.descendInputOfBlock(block, "CLASS")
+          }),
+          instanceof: (generator, block) => ({
+            kind: "input",
+            "class": generator.descendInputOfBlock(block, "CLASS"),
+            obj: generator.descendInputOfBlock(block, "OBJECT")
           })
         },
         js: {
@@ -1364,6 +1386,11 @@
           construct: (node, compiler, imports) => {
             const constructor = compiler.descendInput(node.class).asUnknown();
             return new (imports.TypedInput)(`(yield* (runtime.ext_vgscompiledvalues.constructFrom(${constructor})))`, imports.TYPE_UNKNOWN)
+          },
+          instanceof: (node, compiler, imports) => {
+            const constructor = compiler.descendInput(node.class).asUnknown();
+            const obj = compiler.descendInput(node.obj).asUnknown();
+            return new (imports.TypedInput)(`(${obj} instanceof runtime.ext_vgscompiledvalues.getClassToExtend(${constructor}))`, imports.TYPE_BOOLEAN)
           }
         }
       }

--- a/static/extensions/VeryGoodScratcher42/More-Types.js
+++ b/static/extensions/VeryGoodScratcher42/More-Types.js
@@ -492,7 +492,7 @@
           throw "Attempted to construct from non-class."
         }
       }
-      jsValues.getClassToExtend = (strOrClass) => {
+      jsValues.getClassToExtend = (strOrClass, isForInstanceof) => {
         if (jsValues.typeof(strOrClass) === "Class") return strOrClass.class;
         switch (strOrClass) {
           case ("Object"):
@@ -504,7 +504,11 @@
           case ("Map"):
             return jsValues.Map;
           default:
-            throw "Tried to extend invalid value"
+            if (!isForInstanceof) {
+	      throw "Tried to extend invalid value"
+	    } else {
+	      throw "Invalid class for instanceof"
+	    }
         }
       }
       jsValues.isObject = (value) => {
@@ -1390,7 +1394,7 @@
           instanceof: (node, compiler, imports) => {
             const constructor = compiler.descendInput(node.class).asUnknown();
             const obj = compiler.descendInput(node.obj).asUnknown();
-            return new (imports.TypedInput)(`(${obj} instanceof runtime.ext_vgscompiledvalues.getClassToExtend(${constructor}))`, imports.TYPE_BOOLEAN)
+            return new (imports.TypedInput)(`(${obj} instanceof runtime.ext_vgscompiledvalues.getClassToExtend(${constructor}, true))`, imports.TYPE_BOOLEAN)
           }
         }
       }


### PR DESCRIPTION
uhhh i saw the OOP extension from live tests and decided to reimplement it in more types.

this update adds classes, methods, this, instanceof block and a version of the for key value block for tempVars (cuz scratch variables boring)