### PR TITLE
Fix Toast Notifs

### DIFF
--- a/static/extensions/MubiLop/toastnotifs.js
+++ b/static/extensions/MubiLop/toastnotifs.js
@@ -504,7 +504,7 @@
       document.head.appendChild(alertStyle);
 
       var alert = document.createElement("div");
-      alert.className = `alert ${type}`;
+      alert.className = `alert`;
       alert.textContent = text;
       document.body.appendChild(alert);
 


### PR DESCRIPTION
Error:
![image](https://github.com/user-attachments/assets/17d26b11-9dd8-4682-8128-4b5b394aa23f)

Text Error:
ReferenceError: type is not defined

What happened?
"type" was tried to be used, but it wasnt existent.