### PR TITLE
Fix typo for unstable extension warning

### DIFF
--- a/src/lib/extensions.js
+++ b/src/lib/extensions.js
@@ -66,7 +66,7 @@ export default [
         creator: "yuri-kiss",
         isGitHub: true,
         unstable: true,
-        unstableReason: "This extension uses unstable technuiqes that may not always work.",
+        unstableReason: "This extension uses unstable techniques that may not always work.",
     },
     {
         name: "Variables Expanded",


### PR DESCRIPTION
Self explanatory. This PR is quite pointless since all I did was fix a typo.
<img width="298" alt="Screenshot 2024-12-04 at 12 09 47 PM" src="https://github.com/user-attachments/assets/0ec4d118-4da5-4633-8cf9-6e37eb31c3ae">
