### PR TITLE
Extension fix: Fix a typo in 3D-Math.js that caused the dot product of a 3D vector to not work

### DIFF
--- a/static/extensions/ObviousAlexC/3DMath.js
+++ b/static/extensions/ObviousAlexC/3DMath.js
@@ -1021,7 +1021,7 @@
       a = JSON.parse(a);
       b = JSON.parse(b);
       if (a.length == 3 && b.length == 3) {
-        return a[0] * b[0] + a[1] * b[1] + a[2] + b[2];
+        return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
       }
       return 0;
     }


### PR DESCRIPTION
Previous code:
`return a[0] * b[0] + a[1] * b[1] + a[2] + b[2];`
`a[2]` and `b[2]` were added instead of multiplied

New change:
`return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];`