### PR TITLE
NumberUtilities | Fix Clump function

### DIFF
--- a/static/extensions/MubiLop/numutils.js
+++ b/static/extensions/MubiLop/numutils.js
@@ -305,8 +305,8 @@
 
     clamp(args) {
       const num = Cast.toNumber(args.NUMBER);
-      const min = Cast.toNumber(args.MIN);
-      const max = Cast.toNumber(args.MAX);
+      let min = Cast.toNumber(args.MIN);
+      let max = Cast.toNumber(args.MAX);
       
       // swap stuff
       if (min > max) {


### PR DESCRIPTION
[fix: change from const to let because we change the variables.](https://github.com/PenguinMod/PenguinMod-ExtensionsGallery/commit/d9b955ede0e4fe3fa275b144d57b12b9538e705e)

**Image from the person that reported the issue**
<img width="711" height="709" alt="image" src="https://github.com/user-attachments/assets/cd06c27e-ba88-44f3-bdc0-521401f6175c" />
