### PR TITLE
Escaping html in custom render handler

### DIFF
--- a/static/extensions/DogeisCut/dogeiscutObject.js
+++ b/static/extensions/DogeisCut/dogeiscutObject.js
@@ -37,6 +37,15 @@
         return false
     }
 
+    function escapeHTML (unsafe) {
+        return unsafe
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;")
+            .replaceAll('"', "&quot;")
+            .replaceAll("'", "&#039;")
+    }
+
     class ObjectType {
         customId = "dogeiscutObject"
 
@@ -178,9 +187,9 @@
                         } else if (RENDER_ARRAYS_VISUALLY && (isArray(value) || (jwArray && value instanceof jwArray.Type))) {
                             valueCell.appendChild(renderArray(isArray(value) ? value : (value.array || [])));
                         } else if (typeof value.dogeiscutObjectHandler === "function") {
-                            valueCell.innerHTML = value.dogeiscutObjectHandler();
+                            valueCell.innerHTML = escapeHTML(value.dogeiscutObjectHandler());
                         } else if (typeof value.jwArrayHandler === "function") {
-                            valueCell.innerHTML = value.jwArrayHandler();
+                            valueCell.innerHTML = escapeHTML(value.jwArrayHandler());
                         } else {
                             valueCell.appendChild(renderObject(value));
                         }
@@ -247,9 +256,9 @@
                         } else if (RENDER_ARRAYS_VISUALLY && (isArray(item) || (jwArray && item instanceof jwArray.Type))) {
                             valCell.appendChild(renderArray(isArray(item) ? item : (item.array || [])));
                         } else if (typeof item.dogeiscutObjectHandler === "function") {
-                            valCell.innerHTML = item.dogeiscutObjectHandler();
+                            valCell.innerHTML = escapeHTML(item.dogeiscutObjectHandler());
                         } else if (typeof item.jwArrayHandler === "function") {
-                            valCell.innerHTML = item.jwArrayHandler();
+                            valCell.innerHTML = escapeHTML(item.jwArrayHandler());
                         } else {
                             valCell.appendChild(renderObject(item));
                         }


### PR DESCRIPTION
`dogeiscutObjectHandler` just assigned `innerHTML` to anything by the handler before.
This can't be fixed within implementations of `dogeiscutObjectHandler` as sometimes its just used in a conversion to string, which would then show html source code or other trails like `"&lt;"`.

Alternative: add an argument to `dogeiscutObjectHandler` specifying if the result is put into HTML and therefore needs to be escaped.