### PR TITLE
TheShovel/extexp.js: QOL changes

### DIFF
--- a/static/extensions/TheShovel/extexp.js
+++ b/static/extensions/TheShovel/extexp.js
@@ -76,21 +76,17 @@
         },
       };
     }
-    // NOTE: This is only meant to return Object values and nothing else (no Arrays or null)
+    // NOTE: This is only meant to return object values and nothing else (no Arrays or null as they don't count here)
     _convertToObject(obj) {
       if (typeof obj === 'object') {
-        if (
-          obj === null ||
-          !Object.is(Object.getPrototypeOf(obj), Object.prototype)
-        ) return {};
+        if (obj === null || Array.isArray(obj)) return {};
+        // NOTE: Unlike the "JSON.parse" this is not guarenteed to actually be a safe object to pass around.
         return obj;
       }
       try {
         obj = JSON.parse(obj);
-        if (
-          obj === null ||
-          !Object.is(Object.getPrototypeOf(obj), Object.prototype)
-        ) return {};
+        // "JSON.parse" only returns Object, Array and null as "object-like" values.
+        if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) return {};
         return obj;
       } catch {
         return {};


### PR DESCRIPTION
Do not close this pull request under past pretense that the code is the same, whatever gripes JWK had with this have been completely changed to match a less strict and more user friendly alternative suggested by jeremy. and for jodie, if you read the code and the previous pull request comments this does not break functionality.

This pull request:
- 1. Improves compatibility with other extensions
- 2. Fixes a object conversion bug where it sometimes doesnt actually return an object value.
- 3. Fixes a bug in the "get blocks" block where it would return blocks that do not exist or have opcodes.
- 4. Adds a basic block check that can be disabled.

If I missed something then just comment it and I will add it.

This improves the speed of the run function based on benchmarks I did (GSA's used my outdated code he said): https://github.com/PenguinMod/PenguinMod-ExtensionsGallery/pull/417#discussion_r2551946287

supersceeds the illy closed https://github.com/PenguinMod/PenguinMod-ExtensionsGallery/pull/417/ after a big review by GSA