### PR TITLE
Fix typo in Sets description for clarity

### DIFF
--- a/src/lib/extensions.js
+++ b/src/lib/extensions.js
@@ -241,7 +241,7 @@ export default [
     },
     {
         name: "Sets",
-        description: "Store non-repeating, unordered, data super efficently in sets.",
+        description: "Store non-repeating, unordered data super efficiently in sets.",
         code: "DogeisCut/dogeiscutSet.js",
         banner: "DogeisCut/dogeiscutSet.svg",
         creator: "DogeisCut",


### PR DESCRIPTION
Just noticed a small typo in the "Sets" extension.