### PR TITLE
Add Story Weaver extension by ThatBobo

### DIFF
--- a/Story Weaver
+++ b/Story Weaver
@@ -1,0 +1,188 @@
+// Story Weaver - PenguinMod Extra Extension
+// Version: 1.0.0
+// Author: Your Name
+// Description: Blocks for writing and managing text stories in Scratch.
+
+static/extensions/thatbobo/storyweaver.js
+/* Story Weaver Extension - GitHub-ready version */
+
+(async function(Scratch) {
+    // Check if the extension can run unsandboxed
+    if (!Scratch.extensions.unsandboxed) {
+        alert("This extension needs to be unsandboxed to run!");
+        return;
+    }
+
+    const ExtForge = {
+        Broadcasts: new function() {
+            this.raw = {};
+            this.register = (name, blocks) => { this.raw[name] = blocks; };
+            this.execute = async (name) => { if (this.raw[name]) { await this.raw[name]; } };
+        },
+        Variables: new function() {
+            this.raw = {};
+            this.set = (name, value) => { this.raw[name] = value; };
+            this.get = (name) => { return this.raw[name] ?? null; }
+        },
+        Vector: class {
+            constructor(x, y) { this.x = x; this.y = y }
+            static from(v) {
+                if (v instanceof ExtForge.Vector) return v;
+                if (v instanceof Array) return new ExtForge.Vector(Number(v[0]), Number(v[1]));
+                if (v instanceof Object) return new ExtForge.Vector(Number(v.x), Number(v.y));
+                return new ExtForge.Vector();
+            }
+            add(v) { return new ExtForge.Vector(this.x + v.x, this.y + v.y); }
+            set(x, y) { return new ExtForge.Vector(x ?? this.x, y ?? this.y); }
+        },
+        Utils: {
+            setList: (list, index, value) => { list[index] = value; return list; },
+            lists_foreach: { index: [0], value: [null], depth: 0 },
+            countString: (x, y) => { return y.length == 0 ? 0 : x.split(y).length - 1; }
+        }
+    };
+
+    class Extension {
+        getInfo() {
+            return {
+                "id": "thatbobostoryweaver",
+                "name": "Story Weaver",
+                "color1": "#00ffff",
+                "blocks": [
+                    {
+                        "opcode": "writeText",
+                        "text": "Write: [text]",
+                        "blockType": "command",
+                        "arguments": { "text": { "type": "string", "defaultValue": "" } }
+                    },
+                    {
+                        "opcode": "removeText",
+                        "text": "Remove: [text]",
+                        "blockType": "command",
+                        "arguments": { "text": { "type": "string" } }
+                    },
+                    { "opcode": "startNewStory", "text": "Start new story", "blockType": "command", "arguments": {} },
+                    {
+                        "opcode": "setStoryTitle",
+                        "text": "Set story title to: [title]",
+                        "blockType": "command",
+                        "arguments": { "title": { "type": "string" } }
+                    },
+                    { "opcode": "finishStory", "text": "Story done", "blockType": "command", "arguments": {} },
+                    { "opcode": "showStory", "text": "Show story", "blockType": "command", "arguments": {} },
+                    { "opcode": "getStories", "text": "Stories", "blockType": "reporter", "arguments": {} },
+                    {
+                        "opcode": "switchStory",
+                        "text": "Switch to story [storyTitle]",
+                        "blockType": "command",
+                        "arguments": { "storyTitle": { "type": "string", "defaultValue": "" } }
+                    },
+                    { "opcode": "getCurrentStory", "text": "Current story", "blockType": "reporter", "arguments": {} }
+                ],
+                "menus": {}
+            };
+        }
+
+        // Add text to current story
+        async writeText(args) {
+            let story = ExtForge.Variables.get("Current story");
+            if (story) {
+                story.text += args.text;
+                ExtForge.Variables.set("Current story", story);
+                ExtForge.Variables.set("Text to write", story.text);
+            } else {
+                ExtForge.Variables.set("Text to write", args.text);
+            }
+            alert(`Wrote "${args.text}" to story`);
+        }
+
+        // Remove text from current story
+        async removeText(args) {
+            let text = ExtForge.Variables.get("Text to write") || "";
+            text = text.replace(args.text, "");
+            ExtForge.Variables.set("Text to write", text);
+
+            let story = ExtForge.Variables.get("Current story");
+            if (story) {
+                story.text = text;
+                ExtForge.Variables.set("Current story", story);
+            }
+            alert(`Removed "${args.text}" from story`);
+        }
+
+        // Start a new story
+        async startNewStory() {
+            ExtForge.Variables.set("Story title", "");
+            ExtForge.Variables.set("Text to write", "");
+            ExtForge.Variables.set("Current story", null);
+            alert("Started a new story");
+        }
+
+        // Set the story title
+        async setStoryTitle(args) {
+            ExtForge.Variables.set("Story title", args.title);
+            alert(`Story title set to "${args.title}"`);
+        }
+
+        // Finish and save the story
+        async finishStory() {
+            let stories = ExtForge.Variables.get("Stories") || [];
+            let title = ExtForge.Variables.get("Story title") || "(no title)";
+            let text = ExtForge.Variables.get("Text to write") || "(no text yet)";
+            stories.push({ title, text });
+            ExtForge.Variables.set("Stories", stories);
+            ExtForge.Variables.set("Story title", "");
+            ExtForge.Variables.set("Text to write", "");
+            ExtForge.Variables.set("Current story", null);
+            alert(`Saved story "${title}"`);
+        }
+
+        // Show current story
+        async showStory() {
+            let story = ExtForge.Variables.get("Current story");
+            if (story) {
+                alert(story.title + "\n" + story.text);
+            } else {
+                let title = ExtForge.Variables.get("Story title") || "(no title)";
+                let text = ExtForge.Variables.get("Text to write") || "(no text yet)";
+                alert(title + "\n" + text);
+            }
+        }
+
+        // List all story titles
+        async getStories() {
+            let stories = ExtForge.Variables.get("Stories") || [];
+            return stories.map(story => story.title);
+        }
+
+        // Switch to an existing story
+        async switchStory(args) {
+            let stories = ExtForge.Variables.get("Stories") || [];
+            let story = stories.find(s => s.title === args.storyTitle);
+            if (story) {
+                ExtForge.Variables.set("Story title", story.title);
+                ExtForge.Variables.set("Text to write", story.text);
+                ExtForge.Variables.set("Current story", story);
+                alert(`Switched to story "${story.title}"`);
+            } else {
+                alert("Story not found");
+            }
+        }
+
+        // Get current story title + text
+        async getCurrentStory() {
+            let story = ExtForge.Variables.get("Current story");
+            if (story) {
+                return story.title + "\n" + story.text;
+            } else {
+                let title = ExtForge.Variables.get("Story title") || "(no title)";
+                let text = ExtForge.Variables.get("Text to write") || "(no text yet)";
+                return title + "\n" + text;
+            }
+        }
+    }
+
+    let extension = new Extension();
+    Scratch.extensions.register(extension);
+
+})(Scratch);


### PR DESCRIPTION
### Description
Adds Story Weaver extension: write, manage, and switch between stories in Scratch. Includes JS file and thumbnail. Suitable for ages 7+.

Story Weaver allows users to:
- Write and manage stories within Scratch.
- Remove text from the story.
- Set story titles and save completed stories.
- Switch between multiple stories.

### Files Added
- `static/extensions/ThatBobo/story-weaver.js` → Extension JS file.
- `static/images/ThatBobo/storyweaver.png` → Thumbnail/cover image.

### Notes
- Extension ID: `thatbobostoryweaver`
- Fully self-contained; no external dependencies.
- Uses alert messages for user feedback.
- Suitable for ages 7+.

### Load Extension
Users can load Story Weaver via URL:

https://raw.githubusercontent.com/ThatBobo/PenguinMod-ExtensionsGallery/main/static/extensions/ThatBobo/story-weaver.js

This PR adds the extension to the gallery so users can load it via PenguinMod Extra Extensions.