### PR TITLE
Objects: Use grey in reporter bubble

### DIFF
--- a/static/extensions/DogeisCut/dogeiscutObject.js
+++ b/static/extensions/DogeisCut/dogeiscutObject.js
@@ -113,7 +113,7 @@
             return JSON.stringify(this.object, null, pretty ? "\t" : null)
         }
 
-        toVisualContent(border = '1px solid #77777777', keyBackground = '#77777711', background = '#ffffff00') {
+        toVisualContent(border = '1px solid #77777777', keyBackground = '#77777724', background = '#ffffff00') {
             // wasnt sure how i wanted this to look so i have some customization
             const RENDER_ARRAYS_VISUALLY = true;
             const SHOW_ARRAY_INDEX_NUMBERS = false;


### PR DESCRIPTION
New:
<img width="254" height="202" alt="msedge_P6Q8PvFJVA" src="https://github.com/user-attachments/assets/4c127a7f-babf-4722-a37a-12558148de30" />
<img width="301" height="222" alt="msedge_Re37GtxtTF" src="https://github.com/user-attachments/assets/d911f00b-fcc0-43bb-98a5-c3700c9db67e" />

Old:
<img width="311" height="196" alt="msedge_4LmYXRjP3Q" src="https://github.com/user-attachments/assets/1953a920-e5cd-4095-82a4-ff3c33149c60" />
<img width="293" height="199" alt="msedge_8cUhg22MNE" src="https://github.com/user-attachments/assets/5fbd9013-140c-4429-ac30-f5fa556f428d" />
