### PR TITLE
ToastNotifs | fix toast block no image

### DIFF
--- a/static/extensions/MubiLop/toastnotifs.js
+++ b/static/extensions/MubiLop/toastnotifs.js
@@ -526,7 +526,7 @@
              type: 'origin',
              text: xmlEscape(Cast.toString(args.TITLE)),
              message: xmlEscape(Cast.toString(args.MESSAGE)),
-             position: 'bottom-right'
+             position: xmlEscape(Cast.toString(args.POSITION))
           });
        }
 


### PR DESCRIPTION
for some reason it was manually putting bottom-right, just found out about it