### PR TITLE
Regular Expressions: i might be stupid

### DIFF
--- a/static/extensions/DogeisCut/dogeiscutRegularExpressions.js
+++ b/static/extensions/DogeisCut/dogeiscutRegularExpressions.js
@@ -207,11 +207,7 @@
             this.regex.lastIndex = Cast.toNumber(newLastIndex)
         }
 
-        exec(string) {
-            // returns an array or null. need arrays ext
-            // also this array aparently has additional properties.. i love js 
-            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
-            let baseArray = this.regex.exec(string)
+        static convertEvilArrayIHateToObject(baseArray) {
             if (baseArray) {
                 let newObj = Object.create(null);
                 newObj.array = vm.jwArray.Type.toArray([...baseArray])
@@ -229,7 +225,15 @@
                 }
                 return vm.dogeiscutObject.Type.toObject(newObj)
             }
-            return "" //returning an empty object felt weird
+            return ""
+        }
+
+        exec(string) {
+            // returns an array or null. need arrays ext
+            // also this array aparently has additional properties.. i love js 
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
+            let baseArray = this.regex.exec(string)
+            return RegularExpressionType.convertEvilArrayIHateToObject(baseArray)
         }
         test(string) {
             return Cast.toBoolean(this.regex.test(string))
@@ -557,7 +561,7 @@
             REGEX = RegularExpressionType.toRegularExpression(REGEX)
             STRING = Cast.toString(STRING)
             try {
-                return vm.jwArray.Type.toArray([...STRING.matchAll(REGEX.regex)])
+                return vm.jwArray.Type.toArray([...STRING.matchAll(REGEX.regex)].map((x) => RegularExpressionType.convertEvilArrayIHateToObject(x)))
             } catch {
                 return ""
             }


### PR DESCRIPTION
<img width="517" height="139" alt="image" src="https://github.com/user-attachments/assets/86a75b8a-bd01-4525-8c6f-ec5c8898ebeb" />
Yeah turns out `matchAll` returns an iterator, not an array.

We currently don't have an extension to handle iterators.

I have hidden the block.
<img width="270" height="116" alt="image" src="https://github.com/user-attachments/assets/cc75a7a1-d903-417e-8925-3563b4373e9b" />

Don't worry about the error, this block was unusable anyways. Ideally I'd change its shape too since its not supposed to be an array but that would break things.