### PR TITLE
Remove "custom CSS" block from Project Interfaces docs

### DIFF
--- a/src/lib/Documentation/ProjectInterfaces.md
+++ b/src/lib/Documentation/ProjectInterfaces.md
@@ -43,14 +43,10 @@ Lets take an input element for example, under the "Inputs" section of the extens
 ## Advanced
 It's important to note that Project Interfaces uses [HTML elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements) to create GUI's in projects.
 
-This extension has several blocks to further customize elements for those who have a deeper understanding of HTML and CSS.
-
 The "Create html element" block will allow you to create an element based of a HTML tag of your choice.
-The "Set custom CSS" block will override an elements CSS properties.
 
 ```scratch
 Create html element [h1] with ID [HTML header] :: #707eff
-Set custom CSS of [HTML header] to [background-color: red] :: #707eff
 ```
 
 ## Security

--- a/static/extensions/LordCat0/ProjectInterfaces.js
+++ b/static/extensions/LordCat0/ProjectInterfaces.js
@@ -322,6 +322,7 @@
                                 defaultValue: "background-color: red",
                             },
                         },
+                        hideFromPalette: true
                     },
                     {
                         opcode: "HtmlElement",
@@ -906,17 +907,7 @@
             element.style.backgroundColor = args.color;
         }
         CustomCSS (args) {
-            if (!elements[args.id]) {
-                return;
-            }
-            let style = document.getElementById(`LCGuiStyle_${args.id}`);
-            let lines = args.css.split(";");
-            if (!style) {
-                style = document.createElement("style");
-                style.id = `LCGuiStyle_${args.id}`;
-                document.head.append(style);
-            }
-            style.textContent = `[data-id='${args.id}']{\n${lines.join(" !important;\n") + " !important"}\n}`;
+            // Legacy block that is now non-functional
         }
         HtmlElement (args) {
             if (elements[args.id]) return;


### PR DESCRIPTION
The custom CSS block was hidden in the extension recently and it doesn't make sense for it to be in the documentation anymore.