### PR TITLE
Delist More Types Extension

### DIFF
--- a/src/lib/extensions.js
+++ b/src/lib/extensions.js
@@ -548,14 +548,14 @@ export default [
         creator: "WAYLIVES",
         isGitHub: false,
     },
-    {
+    /*{
         name: "More Types",
         description: "Adds more value types to PenguinMod, implementing Functions, Objects, Arrays, Sets, Maps, Symbols and Nothing.",
         code: "VeryGoodScratcher42/More-Types.js",
         banner: "VeryGoodScratcher42/More-Types.avif",
         creator: "VeryGoodScratcher42",
         isGitHub: false,
-    },
+    },*/
     {
         name: "oneko",
         description: "Cute cat that follows you on the block area.",


### PR DESCRIPTION
I think the more types extension has been largely superseded by the core object, array, and lambda extensions, as well as the set extension. The more types extension is hard to use, and a lot of blocks are repurposed for multiple types rather than being specialized to do one thing while not using the new type API, which makes blocks look really long and anti-visual-coding. I think the extension is quite chaotic and not very useful with all of the better, cleaner alternatives.

For these reasons, I would like to delist the more types extension.